### PR TITLE
R5: Fix Currency Input Parsing (Frontend)

### DIFF
--- a/src/components/AddBillForm.tsx
+++ b/src/components/AddBillForm.tsx
@@ -3,6 +3,7 @@ import { api } from "@/convex/_generated/api";
 import { useConvexMutation } from "@convex-dev/react-query";
 import { showToast } from "./feedback/SciFiToast";
 import { useUser } from "@clerk/tanstack-react-start";
+import { dollarsToCents } from "~/lib/currency";
 
 export function AddBillForm(props: { onSuccess?: () => void }) {
 	const addBill = useConvexMutation(api.bills.upsertBill);
@@ -10,9 +11,10 @@ export function AddBillForm(props: { onSuccess?: () => void }) {
 	const { user } = useUser();
 
 	async function handleSubmit(value: BillFormValues) {
+		const amountCents = dollarsToCents(value.amount);
 		const billId = await addBill({
 			name: value.name,
-			amount: parseFloat(value.amount),
+			amount: amountCents,
 			dueType: value.dueType,
 			dayDue: value.dueType === "Fixed" ? Number(value.dayDue) : undefined,
 			isAutoPay: value.isAutoPay,
@@ -28,7 +30,7 @@ export function AddBillForm(props: { onSuccess?: () => void }) {
 		});
 		showToast({
 			title: "Bill added successfully!",
-			description: `${value.name} — $${parseFloat(value.amount).toFixed(2)} (${value.dueType}${value.isAutoPay ? ", Auto-Pay" : ""})`,
+			description: `${value.name} — $${parseFloat(value.amount.replace(/,/g, "")).toFixed(2)} (${value.dueType}${value.isAutoPay ? ", Auto-Pay" : ""})`,
 		});
 		if (typeof props.onSuccess === "function") props.onSuccess();
 	}

--- a/src/components/EditBillForm.tsx
+++ b/src/components/EditBillForm.tsx
@@ -3,17 +3,20 @@ import { api } from "convex/_generated/api";
 import { useConvexMutation } from "@convex-dev/react-query";
 import { showToast } from "./feedback/SciFiToast";
 import { useUser } from "@clerk/tanstack-react-start";
+import { Doc } from "convex/_generated/dataModel";
+import { dollarsToCents, formatCentsAsDollars } from "~/lib/currency";
 
-export function EditBillForm({ bill, onSuccess }: { bill: any; onSuccess?: () => void }) {
+export function EditBillForm({ bill, onSuccess }: { bill: Doc<"bills">; onSuccess?: () => void }) {
 	const updateBill = useConvexMutation(api.bills.upsertBill);
 	const logActivity = useConvexMutation(api.activity.logActivity);
 	const { user } = useUser();
 
 	async function handleSubmit(value: BillFormValues) {
+		const amountCents = dollarsToCents(value.amount);
 		await updateBill({
 			id: bill._id,
 			name: value.name,
-			amount: parseFloat(value.amount),
+			amount: amountCents,
 			dueType: value.dueType,
 			dayDue: value.dueType === "Fixed" ? Number(value.dayDue) : undefined,
 			isAutoPay: value.isAutoPay,
@@ -21,8 +24,8 @@ export function EditBillForm({ bill, onSuccess }: { bill: any; onSuccess?: () =>
 		// Compute changes array
 		const changes: Array<{ field: string; before: unknown; after: unknown }> = [];
 		if (bill.name !== value.name) changes.push({ field: "name", before: bill.name, after: value.name });
-		if (bill.amount !== parseFloat(value.amount))
-			changes.push({ field: "amount", before: bill.amount, after: parseFloat(value.amount) });
+		if (bill.amount !== amountCents)
+			changes.push({ field: "amount", before: bill.amount, after: amountCents });
 		if (bill.dueType !== value.dueType)
 			changes.push({ field: "dueType", before: bill.dueType, after: value.dueType });
 		if ((bill.dayDue ?? undefined) !== (value.dueType === "Fixed" ? Number(value.dayDue) : undefined))
@@ -56,7 +59,7 @@ export function EditBillForm({ bill, onSuccess }: { bill: any; onSuccess?: () =>
 		<BillForm
 			initialValues={{
 				name: bill.name,
-				amount: bill.amount?.toString() ?? "",
+				amount: formatCentsAsDollars(bill.amount),
 				dueType: bill.dueType,
 				dayDue: bill.dayDue?.toString() ?? "",
 				isAutoPay: bill.isAutoPay,

--- a/src/components/RecentActivityViews/BillPaidActivityAccordion.tsx
+++ b/src/components/RecentActivityViews/BillPaidActivityAccordion.tsx
@@ -52,7 +52,7 @@ export function BillPaidActivityAccordion({ activity }: { activity: BillPaidActi
 				</div>
 				<div className="flex flex-col gap-1">
 					<div className="text-3xl font-extrabold text-green-300 mb-2">
-						{formatCurrency(billQuery.data.amount)}
+						{formatCurrency(billQuery.data.amount / 100)}
 					</div>
 					<div className="flex gap-2">
 						<span className="font-semibold text-zinc-400">Due Date:</span>

--- a/src/components/UnpaidBillsSection.tsx
+++ b/src/components/UnpaidBillsSection.tsx
@@ -99,7 +99,7 @@ export function UnpaidBillsSection({
 									</span>
 									<span className="text-zinc-400 text-xs">
 										Amount:{" "}
-										{(payment.bill?.amount ?? 0).toLocaleString("en-US", {
+										{((payment.bill?.amount ?? 0) / 100).toLocaleString("en-US", {
 											style: "currency",
 											currency: "USD",
 										})}

--- a/src/components/form/CurrencyInput.tsx
+++ b/src/components/form/CurrencyInput.tsx
@@ -17,7 +17,7 @@ export function CurrencyInput({ value, onChange, onBlur, placeholder = "Amount (
 
 	const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
 		if (onBlur) onBlur(e);
-		const num = Number(value);
+		const num = Number(value.replace(/,/g, ""));
 		if (!isNaN(num) && value !== "") {
 			onChange(
 				new Intl.NumberFormat("en-US", {

--- a/src/hooks/use-spending-money.ts
+++ b/src/hooks/use-spending-money.ts
@@ -65,7 +65,7 @@ export function useSpendingMoney() {
 			const isDayAfterEomPaycheck = includeDayAfter != null && due.hasSame(includeDayAfter, "day");
 
 			if (isBeforeNextPaycheck || isDayAfterEomPaycheck) {
-				return sum + (payment.bill.amount ?? 0);
+				return sum + ((payment.bill.amount ?? 0) / 100);
 			}
 			return sum;
 		},

--- a/src/lib/billFieldFormatters.ts
+++ b/src/lib/billFieldFormatters.ts
@@ -2,10 +2,10 @@
 
 import { formatCurrency, formatOrdinal } from "~/utils/formatters";
 
-export function formatBillFieldValue(field: string, value: any) {
+export function formatBillFieldValue(field: string, value: string | number | boolean | undefined | null) {
 	if (field === "amount") {
 		const num = typeof value === "number" ? value : Number(value?.toString().replace(/,/g, ""));
-		return isNaN(num) ? value : formatCurrency(num);
+		return isNaN(num) ? String(value) : formatCurrency(num / 100);
 	}
 	if (field === "dayDue") {
 		const num = typeof value === "number" ? value : Number(value);

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,0 +1,14 @@
+/** Strip commas and convert a dollar string to integer cents */
+export function dollarsToCents(value: string): number {
+	return Math.round(parseFloat(value.replace(/,/g, "")) * 100);
+}
+
+/** Convert integer cents to a dollar amount (number) */
+export function centsToDollars(cents: number): number {
+	return cents / 100;
+}
+
+/** Convert integer cents to a formatted dollar display string (e.g. "12.00") */
+export function formatCentsAsDollars(cents: number): string {
+	return (cents / 100).toFixed(2);
+}

--- a/src/routes/bills.tsx
+++ b/src/routes/bills.tsx
@@ -18,12 +18,14 @@ import { MissionBanner } from "~/components/ui/MissionBanner";
 import { SciFiDialog } from "~/components/feedback/SciFiDialog";
 import { showToast } from "~/components/feedback/SciFiToast";
 import { EditBillForm } from "~/components/EditBillForm";
+import { Doc } from "convex/_generated/dataModel";
+import { formatCentsAsDollars } from "~/lib/currency";
 
 function BillsPage() {
 	const bills = useSuspenseQuery(convexQuery(api.bills.list, {}));
 	const [showAddDialog, setShowAddDialog] = useState(false);
-	const [billToDelete, setBillToDelete] = useState<any | null>(null);
-	const [billToEdit, setBillToEdit] = useState<any | null>(null);
+	const [billToDelete, setBillToDelete] = useState<Doc<"bills"> | null>(null);
+	const [billToEdit, setBillToEdit] = useState<Doc<"bills"> | null>(null);
 
 	const deleteBillMutation = useConvexMutation(api.bills.deleteBill);
 	const logActivity = useConvexMutation(api.activity.logActivity);
@@ -68,7 +70,7 @@ function BillsPage() {
 						<div className="text-zinc-400 text-center py-8 text-lg">No bills configured yet.</div>
 					) : (
 						<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-							{bills.data?.map((bill: any) => (
+							{bills.data?.map(bill => (
 								<div
 									key={bill._id}
 									className="relative bg-zinc-900 rounded-xl shadow-lg p-4 flex flex-row border border-cyan-900/40 hover:border-cyan-400 hover:shadow-[0_0_16px_0_rgba(34,211,238,0.4)] transition-shadow duration-300 min-h-[120px] overflow-hidden"
@@ -99,7 +101,7 @@ function BillsPage() {
 											</div>
 										</div>
 										<span className="text-neutral-200 text-xl font-extrabold mb-2 tracking-wide">
-											${bill.amount.toFixed(2)}
+											${formatCentsAsDollars(bill.amount)}
 										</span>
 										<div className="flex items-center gap-2 mb-1">
 											<Badge variant="neutral">
@@ -183,10 +185,10 @@ function BillsPage() {
 											description: `${billToDelete.name} was deleted successfully.`,
 											variant: "success",
 										});
-									} catch (err: any) {
+									} catch (err: unknown) {
 										showToast({
 											title: "Delete failed",
-											description: err?.message || "Could not delete bill.",
+											description: err instanceof Error ? err.message : "Could not delete bill.",
 											variant: "error",
 										});
 									}


### PR DESCRIPTION
## Summary
Fix critical parseFloat bug where `"1,200.00"` parses as `1.00` by stripping commas before parsing. Convert all money values to integer cents at form boundaries and format cents back to dollars for display.

## Changes
- **`src/lib/currency.ts`** — New utility: `dollarsToCents()`, `centsToDollars()`, `formatCentsAsDollars()`
- **`src/components/AddBillForm.tsx`** — Strip commas, convert to cents before API call
- **`src/components/EditBillForm.tsx`** — Strip commas, convert to cents; display cents as dollars in form; replaced `any` with `Doc<"bills">`
- **`src/components/form/CurrencyInput.tsx`** — Strip commas in blur handler for re-blur reliability
- **`src/routes/bills.tsx`** — Display cents as dollars; replaced `any` with `Doc<"bills">`; fixed error type
- **`src/components/UnpaidBillsSection.tsx`** — Display cents as dollars
- **`src/hooks/use-spending-money.ts`** — Convert cents to dollars for spending calculation
- **`src/lib/billFieldFormatters.ts`** — Convert cents to dollars in formatter; replaced `any` param type
- **`src/components/RecentActivityViews/BillPaidActivityAccordion.tsx`** — Display cents as dollars

## Acceptance Criteria
- [x] Commas stripped before parsing
- [x] Values converted to integer cents at form boundary
- [x] Display formats cents back to dollars
- [x] `"1,200.00"` correctly becomes `120000` cents

Fixes #6
