### PR TITLE
Fix: Make userId optional for backfill migration

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -33,7 +33,7 @@ export type PlaidItem = Infer<typeof PlaidItemSchema>;
 
 export default defineSchema({
 	bills: defineTable({
-		userId: v.string(),
+		userId: v.optional(v.string()),
 		amount: v.float64(),
 		dayDue: v.optional(v.float64()),
 		dueType: v.union(v.literal("Fixed"), v.literal("EndOfMonth")),
@@ -41,7 +41,7 @@ export default defineSchema({
 		name: v.string(),
 	}).index("byUserId", ["userId"]),
 	billPayments: defineTable({
-		userId: v.string(),
+		userId: v.optional(v.string()),
 		dateDue: v.string(),
 		datePaid: v.optional(v.string()),
 		billId: v.id("bills"),


### PR DESCRIPTION
Existing bills and billPayments records don't have userId yet. Convex schema validation fails on deploy if the field is required.

Make userId optional so deploy succeeds, then run backfill migrations, then tighten back to required.

Hotfix for deploy failure after #32 merge.