### PR TITLE
R6: User Settings Table (Configurable Pay Schedule)

### DIFF
--- a/src/routes/bank/success/$itemId.tsx
+++ b/src/routes/bank/success/$itemId.tsx
@@ -90,18 +90,20 @@ function BankAccountsError({ error }: { error: Error }) {
 }
 
 function BankAccountsList({ data }: { data: Account[] }) {
+	const institutionName = data[0]?.institution?.name;
+
 	return (
 		<BankAccountsLayout>
 			<h1 className="text-2xl font-bold text-cyan-400 mb-2">Bank Linked Successfully!</h1>
-			{data?.institution?.name && (
-				<div className="text-cyan-300 mb-2 text-lg font-semibold">{data.institution.name}</div>
+			{institutionName && (
+				<div className="text-cyan-300 mb-2 text-lg font-semibold">{institutionName}</div>
 			)}
 			<p className="text-zinc-300 mb-6">Your bank account has been linked. Here are the accounts we found:</p>
 			<div className="w-full flex flex-col gap-4">
-				{data?.accounts && data.accounts.length > 0 ? (
-					data.accounts.map((account) => (
+				{data.length > 0 ? (
+					data.map((account) => (
 						<div
-							key={account.account_id || account.id}
+							key={account.account_id}
 							className="bg-zinc-800 rounded-xl p-4 flex flex-col sm:flex-row sm:items-center gap-2 border border-zinc-700"
 						>
 							<div className="flex-1">

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -81,8 +81,10 @@ export type Activity =
 	| BillUpdatedActivity
 	| BillDueActivity;
 
+import { Doc } from "convex/_generated/dataModel";
+
 // Type for Convex backend results (includes _id, _creationTime, etc.)
-export type ActivityDoc = Activity & { _id: string; _creationTime?: number };
+export type ActivityDoc = Doc<"activity">;
 
 // Type guard functions
 export function isBillPaidActivity(activity: Activity): activity is BillPaidActivity {


### PR DESCRIPTION
## Summary
Adds a `userSettings` Convex table so users can configure their pay schedule instead of relying on the hardcoded semimonthly (15th + EOM) logic.

### Changes
- **convex/schema.ts** - new `userSettings` table with `paySchedule` and `payDays` fields, indexed by `userId`
- **convex/userSettings.ts** - `get` query and `upsert` mutation with auth guards
- **src/hooks/use-spending-money.ts** - reads user settings to compute next paycheck date; supports semimonthly, biweekly, weekly, and monthly schedules; defaults to semimonthly [15, 0] when no settings exist

Fixes #7